### PR TITLE
Tells macdoc to load .tree and .zip file

### DIFF
--- a/API Docs/XamarinRobotics-docs.source
+++ b/API Docs/XamarinRobotics-docs.source
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<monodoc>
+  <node label="Xamarin.Robotics Framework" name="Xamarin.Robotics" parent="libraries"/>
+  <source provider="ecma" basefile="Xamarin.Robotics" path="Xamarin.Robotics"/>
+</monodoc>


### PR DESCRIPTION
Copy this file to /Library/Frameworks/Mono.framework/External/monodoc/

Note that the contents of this file assume that the API docs are Xamarin.Robotics.tree and Xamarin.Robotics.zip
