### PR TITLE
Fixed Android's BLE Characteristic's Descriptor list never being created...

### DIFF
--- a/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Characteristic.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Characteristic.cs
@@ -82,7 +82,7 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 		public IList<IDescriptor> Descriptors {
 			get {
 				// if we haven't converted them to our xplat objects
-				if (this._descriptors != null) {
+				if (this._descriptors == null) {
 					this._descriptors = new List<IDescriptor> ();
 					// convert the internal list of them to the xplat ones
 					foreach (var item in this._nativeCharacteristic.Descriptors) {


### PR DESCRIPTION
The if check was checking to see if the object had been created, not to see if was null and needed creation, so the descriptors were always null.
