### PR TITLE
Ensure the same item only appears once on the list

### DIFF
--- a/Sample Apps/BLE Explorer/Robotics.Mobile.BtLEExplorer.Core/Pages/CharacteristicList.xaml.cs
+++ b/Sample Apps/BLE Explorer/Robotics.Mobile.BtLEExplorer.Core/Pages/CharacteristicList.xaml.cs
@@ -14,6 +14,7 @@ namespace Robotics.Mobile.BtLEExplorer
 		IService service; 
 
 		ObservableCollection<ICharacteristic> characteristics;
+		Dictionary<Guid, ICharacteristic> guidToCharacteristic;
 
 		public CharacteristicList (IAdapter adapter, IDevice device, IService service)
 		{
@@ -22,6 +23,7 @@ namespace Robotics.Mobile.BtLEExplorer
 			this.device = device;
 			this.service = service;
 			this.characteristics = new ObservableCollection<ICharacteristic> ();
+			this.guidToCharacteristic = new Dictionary<Guid, ICharacteristic> ();
 
 			listView.ItemsSource = characteristics;
 
@@ -31,7 +33,11 @@ namespace Robotics.Mobile.BtLEExplorer
 				if (characteristics.Count == 0)
 					Device.BeginInvokeOnMainThread(() => {
 						foreach (var characteristic in service.Characteristics) {
-							characteristics.Add(characteristic);
+							if (!guidToCharacteristic.ContainsKey(characteristic.ID))
+							{
+								characteristics.Add(characteristic);
+								guidToCharacteristic.Add(characteristic.ID, characteristic);
+							}
 						}
 					});
 			};

--- a/Sample Apps/BLE Explorer/Robotics.Mobile.BtLEExplorer.Core/Pages/DeviceList.xaml.cs
+++ b/Sample Apps/BLE Explorer/Robotics.Mobile.BtLEExplorer.Core/Pages/DeviceList.xaml.cs
@@ -12,17 +12,23 @@ namespace Robotics.Mobile.BtLEExplorer
 	{	
 		IAdapter adapter;
 		ObservableCollection<IDevice> devices;
+		Dictionary<Guid, IDevice> guidToDevices;
 
 		public DeviceList (IAdapter adapter)
 		{
 			InitializeComponent ();
 			this.adapter = adapter;
 			this.devices = new ObservableCollection<IDevice> ();
+			this.guidToDevices = new Dictionary<Guid, IDevice> ();
 			listView.ItemsSource = devices;
 
 			adapter.DeviceDiscovered += (object sender, DeviceDiscoveredEventArgs e) => {
 				Device.BeginInvokeOnMainThread(() => {
-					devices.Add (e.Device);
+					if (!guidToDevices.ContainsKey(e.Device.ID))
+					{
+						devices.Add (e.Device);
+						guidToDevices.Add(e.Device.ID, e.Device);
+					}
 				});
 			};
 
@@ -66,6 +72,7 @@ namespace Robotics.Mobile.BtLEExplorer
 				Debug.WriteLine ("adapter.StopScanningForDevices()");
 			} else {
 				devices.Clear();
+				guidToDevices.Clear ();
 				adapter.StartScanningForDevices(forService);
 				Debug.WriteLine ("adapter.StartScanningForDevices("+forService+")");
 			}

--- a/Sample Apps/BLE Explorer/Robotics.Mobile.BtLEExplorer.Core/Pages/ServiceList.xaml.cs
+++ b/Sample Apps/BLE Explorer/Robotics.Mobile.BtLEExplorer.Core/Pages/ServiceList.xaml.cs
@@ -13,6 +13,7 @@ namespace Robotics.Mobile.BtLEExplorer
 		IDevice device;
 
 		ObservableCollection<IService> services;
+		Dictionary<Guid, IService> guidToServices;
 
 		public ServiceList (IAdapter adapter, IDevice device)
 		{
@@ -20,6 +21,7 @@ namespace Robotics.Mobile.BtLEExplorer
 			this.adapter = adapter;
 			this.device = device;
 			this.services = new ObservableCollection<IService> ();
+			this.guidToServices = new Dictionary<Guid, IService> ();
 			listView.ItemsSource = services;
 
 			// when device is connected
@@ -33,7 +35,11 @@ namespace Robotics.Mobile.BtLEExplorer
 					if (services.Count == 0)
 						Device.BeginInvokeOnMainThread(() => {
 							foreach (var service in device.Services) {
-								services.Add(service);
+								if (!guidToServices.ContainsKey(service.ID))
+								{
+									services.Add(service);
+									guidToServices.Add(service.ID, service);
+								}
 							}
 						});
 				};


### PR DESCRIPTION
Prior to the change, the same item can be repeated added to the list.
We use a map to ensure the same item (based on ID property) appear only once.