### PR TITLE
Fix phantom delegate trying to use its referenced gatt instance

### DIFF
--- a/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Device.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Device.cs
@@ -33,15 +33,18 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 
 			// when the services are discovered on the gatt callback, cache them here
 			if (this._gattCallback != null) {
-				this._gattCallback.ServicesDiscovered += (s, e) => {
-					var services = this._gatt.Services;
-					this._services = new List<IService> ();
-					foreach (var item in services) {
-						this._services.Add (new Service (item, this._gatt, this._gattCallback));
-					}
-					this.ServicesDiscovered (this, e);
-				};
+				this._gattCallback.ServicesDiscovered += this.OnServiceDiscovered;
 			}
+		}
+
+		public void OnServiceDiscovered(object sender, ServicesDiscoveredEventArgs args)
+		{
+			var services = this._gatt.Services;
+			this._services = new List<IService> ();
+			foreach (var item in services) {
+				this._services.Add (new Service (item, this._gatt, this._gattCallback));
+			}
+			this.ServicesDiscovered (this, args);
 		}
 
 		public override Guid ID {
@@ -104,7 +107,11 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 		public void Disconnect ()
 		{
 			this._gatt.Disconnect ();
-			this._gatt.Dispose ();
+			if (this._gattCallback != null) {
+				this._gattCallback.ServicesDiscovered -= this.OnServiceDiscovered;
+			}
+			this._gatt.Close ();
+			this._gatt = null;
 		}
 
 		#endregion


### PR DESCRIPTION
Prior to the change, when one disconnect a connected device in Android,
Device instance inserts a delegate to GattCallback instance to cache
discovered Services. However, when one disconnects such device, the
delegate is not removed. So upon next device connection, that delegate
will attempt to reference a disposed Gatt instance and cause a crash.

To reproduce this bug, you can try the following sequence:

1) Scan for Devices
2) Connect to Device A
3) Discovers Service of Device A
4) Dsiconnect Device A
5) Connect to Device A again
6) Discovers Service of Device A
7) Crash