### PR TITLE
Refactor Android implementation

### DIFF
--- a/Sample Apps/BLE Explorer/Robotics.Mobile.BtLEExplorer.Core/Pages/ServiceList.xaml.cs
+++ b/Sample Apps/BLE Explorer/Robotics.Mobile.BtLEExplorer.Core/Pages/ServiceList.xaml.cs
@@ -22,6 +22,7 @@ namespace Robotics.Mobile.BtLEExplorer
 			this.services = new ObservableCollection<IService> ();
 			listView.ItemsSource = services;
 			adapter.DeviceConnected += this.OnDeviceConnected;
+			adapter.DeviceDisconnected += this.OnDeviceDisconnected;
 			DisconnectButton.Activated += (sender, e) => {
 				adapter.DisconnectDevice (device);
 				Navigation.PopToRootAsync(); // disconnect means start over
@@ -50,11 +51,29 @@ namespace Robotics.Mobile.BtLEExplorer
 			((ListView)sender).SelectedItem = null; // clear selection
 		}
 
-		public void OnDeviceConnected(object sender, EventArgs args)
+		public void OnDeviceConnected(object sender, DeviceConnectionEventArgs args)
 		{
-			this.adapter.DeviceConnected -= this.OnDeviceConnected;
-			this.device.ServicesDiscovered += this.ServicesDiscovered;
-			this.device.DiscoverServices ();
+			if (args.Device == this.device) {
+				this.adapter.DeviceConnected -= this.OnDeviceConnected;
+				this.device.ServicesDiscovered += this.ServicesDiscovered;
+				this.device.DiscoverServices ();
+			}
+		}
+
+		public void OnDeviceDisconnected(object sender, DeviceConnectionEventArgs args)
+		{
+			if (args.Device == this.device) {
+				this.adapter.DeviceDisconnected -= this.OnDeviceDisconnected;
+				// For robustness reason, its possible to be disconnected from device
+				// right after adding the OnConnected delgate in constructor. 
+				// We do not want DeviceConnected delegate become a hidden bomb.
+				this.adapter.DeviceConnected -= this.OnDeviceConnected;
+				// For robustness reason, its possible we go from device
+				// connected to device disconnected without going through
+				// service discovered. We do not want the service discover
+				// delegate become a hidden bomb.
+				this.device.ServicesDiscovered -= this.ServicesDiscovered;
+			}
 		}
 
 		public void ServicesDiscovered(object sender, EventArgs args)

--- a/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Adapter.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Adapter.cs
@@ -110,21 +110,19 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 
 		public void ConnectToDevice (IDevice device)
 		{
-			var gattCallback = new GattCallback ();
+			var androidBleDevice = (Device)device;
+			var gattCallback = new GattCallback (androidBleDevice);
 			gattCallback.DeviceConnected += (object sender, DeviceConnectionEventArgs e) => {
 				this._connectedDevices.Add ( e.Device);
 				this.DeviceConnected (this, e);
 			};
 
 			gattCallback.DeviceDisconnected += (object sender, DeviceConnectionEventArgs e) => {
-				// TODO: remove the disconnected device from the _connectedDevices list
-				// i don't think this will actually work, because i'm created a new underlying device here.
-				//if(this._connectedDevices.Contains(
+				this._connectedDevices.Remove(e.Device);
 				this.DeviceDisconnected (this, e);
 			};
 
-			var androidBleDevice = (Device)device;
-			androidBleDevice._gattCallback = gattCallback;
+			androidBleDevice.GattCallback = gattCallback;
 			androidBleDevice._gatt = ((BluetoothDevice)device.NativeDevice).ConnectGatt (Android.App.Application.Context, true, gattCallback);
 		}
 

--- a/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Device.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Device.cs
@@ -16,12 +16,12 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 		/// 
 		/// TODO: consider wrapping the Gatt and Callback into a single object and passing that around instead.
 		/// </summary>
-		protected BluetoothGatt _gatt;
+		internal BluetoothGatt _gatt;
 		/// <summary>
 		/// we also track this because of gogole's weird API. the gatt callback is where
 		/// we'll get notified when services are enumerated
 		/// </summary>
-		protected GattCallback _gattCallback;
+		internal GattCallback _gattCallback;
 
 		public Device (BluetoothDevice nativeDevice, BluetoothGatt gatt, 
 			GattCallback gattCallback, int rssi) : base ()

--- a/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Device.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Device.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Android.Bluetooth;
 using System.Linq;
+using System.Threading;
 
 namespace Robotics.Mobile.Core.Bluetooth.LE
 {
@@ -89,8 +90,17 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 
 		public void Disconnect ()
 		{
-			this._gatt.Disconnect ();
-			this._gatt.Dispose ();
+			if (this._gatt != null) {
+				this._gatt.Disconnect ();
+				// From empirical results, simply gatt.disconnect follow by gatt.connect is not sufficient
+				// to reconnect to deviece (on Nexus 7 2013 with Adnroid 5.1.1)
+				// Calling gatt.Close() has more chance on the next connection attempt being successful. 
+				// Being said then, you should avoid using the same gatt client and gatt callback for more
+				// than one device. 
+				this._gatt.Close ();
+				this.GattCallback = null;
+				this._gatt = null;
+			}
 		}
 
 		#endregion

--- a/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Device.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Device.cs
@@ -122,6 +122,11 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 
 		internal GattCallback GattCallback
 		{
+			get
+			{
+				return this._gattCallback;
+			}
+
 			set
 			{
 				this._gattCallback = value;
@@ -131,7 +136,7 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 						var services = this._gatt.Services;
 						this._services = new List<IService> ();
 						foreach (var item in services) {
-							this._services.Add (new Service (item, this._gatt, this._gattCallback));
+							this._services.Add (new Service (item, this));
 						}
 						this.ServicesDiscovered (this, e);
 					};

--- a/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/GattCallback.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/GattCallback.cs
@@ -3,6 +3,9 @@ using Android.Bluetooth;
 
 namespace Robotics.Mobile.Core.Bluetooth.LE
 {
+	/// <summary>
+	/// GattCallback has a 1 to 1 relation to each Device instance.
+	/// </summary>
 	public class GattCallback : BluetoothGattCallback
 	{
 
@@ -10,13 +13,6 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 		public event EventHandler<DeviceConnectionEventArgs> DeviceDisconnected = delegate {};
 		public event EventHandler<ServicesDiscoveredEventArgs> ServicesDiscovered = delegate {};
 		public event EventHandler<CharacteristicReadEventArgs> CharacteristicValueUpdated = delegate {};
-
-		protected Adapter _adapter;
-
-		public GattCallback (Adapter adapter)
-		{
-			this._adapter = adapter;
-		}
 
 		public override void OnConnectionStateChange (BluetoothGatt gatt, GattStatus status, ProfileState newState)
 		{

--- a/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/GattCallback.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/GattCallback.cs
@@ -74,7 +74,7 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 			Console.WriteLine ("OnCharacteristicRead: " + characteristic.GetStringValue (0));
 
 			this.CharacteristicValueUpdated (this, new CharacteristicReadEventArgs () { 
-				Characteristic = new Characteristic (characteristic, gatt, this) }
+				Characteristic = new Characteristic (characteristic, this._device) }
 			);
 		}
 
@@ -85,7 +85,7 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 			Console.WriteLine ("OnCharacteristicChanged: " + characteristic.GetStringValue (0));
 
 			this.CharacteristicValueUpdated (this, new CharacteristicReadEventArgs () { 
-				Characteristic = new Characteristic (characteristic, gatt, this) }
+				Characteristic = new Characteristic (characteristic, this._device) }
 			);
 		}
 

--- a/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/GattCallback.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/GattCallback.cs
@@ -14,19 +14,25 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 		public event EventHandler<ServicesDiscoveredEventArgs> ServicesDiscovered = delegate {};
 		public event EventHandler<CharacteristicReadEventArgs> CharacteristicValueUpdated = delegate {};
 
+		private Device _device;
+
+		public GattCallback(Device device)
+		{
+			this._device = device;
+		}
+
 		public override void OnConnectionStateChange (BluetoothGatt gatt, GattStatus status, ProfileState newState)
 		{
-			Console.WriteLine ("OnConnectionStateChange: ");
 			base.OnConnectionStateChange (gatt, status, newState);
 
-			//TODO: need to pull the cached RSSI in here, or read it (requires the callback)
-			Device device = new Device (gatt.Device, gatt, this, 0);
+			Console.WriteLine ("OnConnectionStateChange: ");
 
+			this._device._profileState = newState;
 			switch (newState) {
 			// disconnected
 			case ProfileState.Disconnected:
 				Console.WriteLine ("disconnected");
-				this.DeviceDisconnected (this, new DeviceConnectionEventArgs () { Device = device });
+				this.DeviceDisconnected (this, new DeviceConnectionEventArgs () { Device = this._device });
 				break;
 				// connecting
 			case ProfileState.Connecting:
@@ -35,7 +41,7 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 				// connected
 			case ProfileState.Connected:
 				Console.WriteLine ("Connected");
-				this.DeviceConnected (this, new DeviceConnectionEventArgs () { Device = device });
+				this.DeviceConnected (this, new DeviceConnectionEventArgs () { Device = this._device });
 				break;
 				// disconnecting
 			case ProfileState.Disconnecting:
@@ -81,6 +87,12 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 			this.CharacteristicValueUpdated (this, new CharacteristicReadEventArgs () { 
 				Characteristic = new Characteristic (characteristic, gatt, this) }
 			);
+		}
+
+		public override void OnReadRemoteRssi (BluetoothGatt gatt, int rssi, GattStatus status)
+		{
+			base.OnReadRemoteRssi (gatt, rssi, status);
+			this._device._rssi = rssi;
 		}
 	}
 }

--- a/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Service.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Service.cs
@@ -7,22 +7,12 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 	public class Service : IService
 	{
 		protected BluetoothGattService _nativeService;
-		/// <summary>
-		/// we have to keep a reference to this because Android's api is weird and requires
-		/// the GattServer in order to do nearly anything, including enumerating services
-		/// </summary>
-		protected BluetoothGatt _gatt;
-		/// <summary>
-		/// we also track this because of gogole's weird API. the gatt callback is where
-		/// we'll get notified when services are enumerated
-		/// </summary>
-		protected GattCallback _gattCallback;
+		protected Device _device;
 
-		public Service (BluetoothGattService nativeService, BluetoothGatt gatt, GattCallback _gattCallback)
+		public Service (BluetoothGattService nativeService, Device device)
 		{
 			this._nativeService = nativeService;
-			this._gatt = gatt;
-			this._gattCallback = _gattCallback;
+			this._device = device;
 		}
 
 		public Guid ID {
@@ -54,7 +44,7 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 				if (this._characteristics == null) {
 					this._characteristics = new List<ICharacteristic> ();
 					foreach (var item in this._nativeService.Characteristics) {
-						this._characteristics.Add (new Characteristic (item, this._gatt, this._gattCallback));
+						this._characteristics.Add (new Characteristic (item, this._device));
 					}
 				}
 				return this._characteristics;
@@ -66,7 +56,7 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 			//TODO: why don't we look in the internal list _chacateristics?
 			foreach (var item in this._nativeService.Characteristics) {
 				if ( string.Equals(item.Uuid.ToString(), characteristic.ID.ToString()) ) {
-					return new Characteristic(item, this._gatt, this._gattCallback);
+					return new Characteristic(item, this._device);
 				}
 			}
 			return null;


### PR DESCRIPTION
commit 4518d95ab835df786af266655cf0cf8def029377
Author: Steven Moy <github@stevenmoy.com>
Date:   Fri May 15 14:37:10 2015 -0700

    Refactor out references to gatt and gattCallback. Instead reference device instance instead.
    
    * This is in preparation to allow read/write of characteristic to check
    if a device is disconnected before attempting those read/write actions.

commit babab5fa952c0afcb78b372b54af23af060a62f7
Author: Steven Moy <github@stevenmoy.com>
Date:   Fri May 15 14:02:51 2015 -0700

    Robustify Connect/Disconnet
    
    * During attempt to connect, if an device already has a Gatt instance, tear it down before
    trying to connect.
    * During attempt to disconnect, tear down the gatt instance to free all the android resources

commit c538bb548244b3284513e3e512d7fd54e5a6e524
Author: Steven Moy <github@stevenmoy.com>
Date:   Fri May 15 14:01:20 2015 -0700

    Check to see if Connection/Disconnect event corresponds to the device in interest.
    
    * Robustify removing delegates upon device disconnection

commit 8ccc7021bcf210ca09c1aa533f60f65214d3e166
Author: Steven Moy <github@stevenmoy.com>
Date:   Fri May 15 11:09:09 2015 -0700

    Refactor anonymous delegate into named method, such that
    we can remove them when the method finishes its work.
    
    Prior to the change, upon re-entry of ServiceList, the
    services entry are added more once because we did not
    remove previous added delegate.
commit d34e05ccdb6211c3c0eb943142a5cbe3a308d1cc
Author: Steven Moy <github@stevenmoy.com>
Date:   Fri May 15 08:31:41 2015 -0700

    Add reference to Device instance inside an GattCallback instance.
    
    * Eliminte the need to create new device instance
    * Wire up RSSI to the device
    * Get DeviceState from the profileState given by GattCallback

commit 4f3f15394362f55ac37c07900e8a6449d3872da7
Author: Steven Moy <github@stevenmoy.com>
Date:   Fri May 15 07:48:46 2015 -0700

    Change GattCallback to be per device instead of a singleton.
    
    When one wants to connect multiple BLE devices, the singleton approach
    doesn't work well. In addition, the adapter class member inside GattCallback
    is not being used, it is deleted as well.
    
    The access modifier of _gatt and _gattcallback inside Device is changed from
    protected to internal. Such that, the Adapter instance can update those fields
    upon connection attempt.