### PR TITLE
Provide access to the RSSI value on device discovery

### DIFF
--- a/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Adapter.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core.Droid/Bluetooth/LE/Adapter.cs
@@ -107,9 +107,8 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 
 			if (!DeviceExistsInDiscoveredList (bleDevice))
 				this._discoveredDevices.Add	(device);
-			// TODO: in the cross platform API, cache the RSSI
 			// TODO: shouldn't i only raise this if it's not already in the list?
-			this.DeviceDiscovered (this, new DeviceDiscoveredEventArgs { Device = device });
+			this.DeviceDiscovered (this, new DeviceDiscoveredEventArgs { Device = device, RSSI = rssi });
 		}
 
 		protected bool DeviceExistsInDiscoveredList(BluetoothDevice device)

--- a/Source/Platform Stacks/Robotics.Mobile.Core.iOS/Bluetooth/LE/Adapter.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core.iOS/Bluetooth/LE/Adapter.cs
@@ -66,7 +66,7 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 				Device d = new Device(e.Peripheral);
 				if(!ContainsDevice(this._discoveredDevices, e.Peripheral ) ){
 					this._discoveredDevices.Add (d);
-					this.DeviceDiscovered(this, new DeviceDiscoveredEventArgs() { Device = d });
+					this.DeviceDiscovered(this, new DeviceDiscoveredEventArgs() { Device = d, RSSI = (int)e.RSSI });
 				}
 			};
 

--- a/Source/Platform Stacks/Robotics.Mobile.Core/Bluetooth/LE/DeviceDiscoveredEventArgs.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core/Bluetooth/LE/DeviceDiscoveredEventArgs.cs
@@ -5,6 +5,7 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 	public class DeviceDiscoveredEventArgs : EventArgs
 	{
 		public IDevice Device;
+		public int RSSI;
 
 		public DeviceDiscoveredEventArgs() : base()
 		{}


### PR DESCRIPTION
Following issue #49 I started implementing some change on the discovery API. Now the eventArgs store the RSSI Value.