### PR TITLE
Fix iOS crash when a characteristic is read with no data

### DIFF
--- a/Source/Platform Stacks/Robotics.Mobile.Core.iOS/Bluetooth/LE/Characteristic.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core.iOS/Bluetooth/LE/Characteristic.cs
@@ -36,7 +36,7 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 
 		public byte[] Value {
 			get { 
-				if (_nativeCharacteristic.Value == null)
+				if (this._nativeCharacteristic.Value == null || this._nativeCharacteristic.Value.Length == 0)
 					return null;
 				return this._nativeCharacteristic.Value.ToArray(); 
 			}


### PR DESCRIPTION
When this._nativeCharacteristic.Value.Length is 0, ToArray will crash with the following error in iOS 8.4

System.ArgumentNullException: Argument cannot be null.
Parameter name: src
  at at (wrapper managed-to-native) System.Runtime.InteropServices.Marshal:copy_from_unmanaged (intptr,int,System.Array,int)
  at System.Runtime.InteropServices.Marshal.Copy (IntPtr source, System.Byte[] destination, Int32 startIndex, Int32 length) [0x00000] in /Users/builder/data/lanes/1503/e6ebd18b/source/mono/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs:146
  at Foundation.NSData.ToArray () [0x00012] in /Users/builder/data/lanes/1503/e6ebd18b/source/maccore/src/Foundation/NSData.cs:50
