### PR TITLE
Pass in a valid device when the device is already connected

### DIFF
--- a/Source/Platform Stacks/Robotics.Mobile.Core/Bluetooth/LE/Extensions.cs
+++ b/Source/Platform Stacks/Robotics.Mobile.Core/Bluetooth/LE/Extensions.cs
@@ -42,7 +42,7 @@ namespace Robotics.Mobile.Core.Bluetooth.LE
 		public static Task<IDevice> ConnectAsync (this IAdapter adapter, IDevice device)
 		{
 			if (device.State == DeviceState.Connected)
-				return Task.FromResult<IDevice> (null);
+				return Task.FromResult<IDevice> (device);
 
 			var tcs = new TaskCompletionSource<IDevice> ();
 			EventHandler<DeviceConnectionEventArgs> h = null;


### PR DESCRIPTION
Device tmpDevice = ConnectAsync(device); 

tmpDevice will be null when it is already connected. I think it makes the calling logic makes more sense if the device is already connected, we return the given device. 